### PR TITLE
change back to 7.3.3

### DIFF
--- a/manifest.toml
+++ b/manifest.toml
@@ -7,7 +7,7 @@ name = "SVG-edit"
 description.en = "Web-based SVG drawing editor working on any modern browser"
 description.fr = "Édition de SVG en ligne fonctionnent avec tout navigateur moderne"
 
-version = "7.2.0~ynh1"
+version = "7.3.3~ynh1"
 
 maintainers = ["ljf"]
 
@@ -45,8 +45,8 @@ ram.runtime = "50M"
 
 [resources]
     [resources.sources.main]
-    url = "https://github.com/SVG-Edit/svgedit/archive/refs/tags/v7.2.0.tar.gz"
-    sha256 = "238ca1507a3f7f33134158fdbc5d7b7ba2adbdedc9189749648d787ea737de7d"
+    url = "https://github.com/SVG-Edit/svgedit/archive/refs/tags/v.7.3.3.tar.gz"
+    sha256 = "c543111cbdc6b72781e957941fa0382f1026d0ada81a31177a5688a9104766d7"
     autoupdate.strategy = "latest_github_release"
 
     [resources.system_user]


### PR DESCRIPTION
## Problem

App was broken. It was updated to 7.3.3 by salamander, and then a bot's automatic update request to 7.2.0 was merged. This brings it back to 7.3.3. see issue #22 

## Solution
I undid what the bot did, and changed the app version to 7.3.3 instead of 2.8.1~ynh5 to prevent future issues.

## PR Status

- [x] Code finished and ready to be reviewed/tested
- [x] The fix/enhancement were manually tested (if applicable)

## Automatic tests

Automatic tests can be triggered on https://ci-apps-dev.yunohost.org/ *after creating the PR*, by commenting "!testme", "!gogogadgetoci" or "By the power of systemd, I invoke The Great App CI to test this Pull Request!". (N.B. : for this to work you need to be a member of the Yunohost-Apps organization)


It should be good to merge, but please be sure to test. I will test myself to double check after submitting this pull request.